### PR TITLE
Make sure `update edx-platform` builds static assets in correct order

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -953,8 +953,8 @@ edxapp_lms_gunicorn_host: 127.0.0.1
 # 'edxapp' upstart job.
 
 service_variants_enabled:
-  - lms
   - cms
+  - lms
 
 #Number of gunicorn worker processes to spawn, as a multiplier to number of virtual cores
 worker_core_mult:


### PR DESCRIPTION
Without this fix one must rebuild static assets every time after
platform update, which takes another 8-10 min