### PR TITLE
Fix letsencrypt

### DIFF
--- a/playbooks/roles/add-letsencrypt-certificate/tasks/main.yml
+++ b/playbooks/roles/add-letsencrypt-certificate/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - set_fact: NGINX_ENABLE_SSL=true
 
-- stat: path="/etc/letsencrypt/live/{{ EDXAPP_SITE_NAME }}/fullchain.pem" 
+- stat: path="/etc/letsencrypt/live/{{ EDXAPP_LMS_SITE_NAME }}/fullchain.pem" 
   register: le_cert_exists
   become_method: sudo
   become: yes
@@ -39,7 +39,7 @@
   when: le_cert_exists.stat.islnk is not defined
 
 - name: Requesting LMS and CMS certificate
-  command: /usr/local/bin/certbot-auto certonly --agree-tos --non-interactive --text --rsa-key-size 2048 --webroot -w /var/www/letsencrypt -d "{{ EDXAPP_SITE_NAME }}" -d "{{ EDXAPP_CMS_SITE_NAME }}" -d "{{ EDXAPP_PREVIEW_LMS_BASE }}"  --register-unsafely-without-email --force-renewal
+  command: /usr/local/bin/certbot-auto certonly --agree-tos --non-interactive --text --rsa-key-size 2048 --webroot -w /var/www/letsencrypt -d "{{ EDXAPP_LMS_SITE_NAME }}" -d "{{ EDXAPP_CMS_SITE_NAME }}" -d "{{ EDXAPP_PREVIEW_LMS_BASE }}"  --register-unsafely-without-email --force-renewal
   become_method: sudo
   become: yes
   become_user: root

--- a/playbooks/roles/add-letsencrypt-certificate/templates/cms.j2
+++ b/playbooks/roles/add-letsencrypt-certificate/templates/cms.j2
@@ -39,8 +39,8 @@ error_page {{ k }} {{ v }};
 
   listen {{ EDXAPP_CMS_SSL_NGINX_PORT }} {{ default_site }} ssl;
 
-  ssl_certificate /etc/letsencrypt/live/{{ EDXAPP_SITE_NAME }}/fullchain.pem;
-  ssl_certificate_key /etc/letsencrypt/live/{{ EDXAPP_SITE_NAME }}/privkey.pem;
+  ssl_certificate /etc/letsencrypt/live/{{ EDXAPP_LMS_SITE_NAME }}/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/{{ EDXAPP_LMS_SITE_NAME }}/privkey.pem;
   # request the browser to use SSL for all connections
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
   {% endif %}

--- a/playbooks/roles/add-letsencrypt-certificate/templates/lms.j2
+++ b/playbooks/roles/add-letsencrypt-certificate/templates/lms.j2
@@ -58,8 +58,8 @@ error_page {{ k }} {{ v }};
   {% if NGINX_ENABLE_SSL and USE_LETSENCRYPT == "yes" %}
   listen {{ EDXAPP_LMS_SSL_NGINX_PORT }} {{ default_site }} ssl;
 
-  ssl_certificate /etc/letsencrypt/live/{{ EDXAPP_SITE_NAME }}/fullchain.pem;
-  ssl_certificate_key /etc/letsencrypt/live/{{ EDXAPP_SITE_NAME }}/privkey.pem;
+  ssl_certificate /etc/letsencrypt/live/{{ EDXAPP_LMS_SITE_NAME }}/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/{{ EDXAPP_LMS_SITE_NAME }}/privkey.pem;
   # request the browser to use SSL for all connections
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
   {% endif %}


### PR DESCRIPTION
@imatviian 
@sidorovdmitry 

please review

We must use EDXAPP_LMS_SITE_NAME instead of EDXAPP_SITE_NAME as LMS site domain.
EDXAPP_SITE_NAME can be defined different from LMS site domain.