### PR TITLE
Run duplicity backups using virtualenv.

### DIFF
--- a/playbooks/roles/configure-backups/defaults/main.yml
+++ b/playbooks/roles/configure-backups/defaults/main.yml
@@ -10,6 +10,13 @@ azure_grades_blobstorage_create: no
 backup_user: root               # Run backups as user
 backup_group: "{{backup_user}}"
 
+backup_venv: /edx/app/venvs/duplicity
+backup_venv_packages:
+  - boto==2.48.0
+  - boto3==1.4.4
+  - botocore==1.5.95
+  - s3transfer==0.1.10
+
 backup_home: /etc/duplicity             # Backup configuration directory
 backup_work: /var/duplicity             # Working directory
 backup_temp_dir: /tmp

--- a/playbooks/roles/configure-backups/tasks/install.yml
+++ b/playbooks/roles/configure-backups/tasks/install.yml
@@ -29,3 +29,10 @@
   become_method: sudo
   become: yes
   become_user: root
+
+- name: install python requirements into venv
+  pip:
+    name: "{{ item }}"
+    virtualenv: "{{ backup_venv }}"
+  with_items: "{{ backup_venv_packages }}"
+

--- a/playbooks/roles/configure-backups/templates/cron.j2
+++ b/playbooks/roles/configure-backups/templates/cron.j2
@@ -4,7 +4,7 @@
 # Run backups
 {% for profile in backup_profiles %}
 {% if profile.schedule|default(None) %}
-{{profile.schedule}} {{profile.user|default(backup_user)}} /usr/bin/duply {{backup_home}}/{{profile.name}} {{profile.action|default('backup')}} --allow-source-mismatch >> {{backup_logdir}}/{{profile.name}}.log 2>&1
+{{profile.schedule}} {{profile.user|default(backup_user)}} PYTHONPATH={{ backup_venv }}/lib/python2.7/site-packages/ /usr/bin/duply {{backup_home}}/{{profile.name}} {{profile.action|default('backup')}} --allow-source-mismatch >> {{backup_logdir}}/{{profile.name}}.log 2>&1
 {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
Use virtualenv during backups

tested at AWS instance courses.edforhumanity.org

test logs:

```
root@ip-10-10-0-213:/etc/cron.d# PYTHONPATH=/edx/app/venvs/duplicity/lib/python2.7/site-packages/ /usr/bin/duply /etc/duplicity/mysql backup --allow-source-mismatch
Start duply v1.9.1, time is 2017-11-07 11:36:35.
Using profile '/etc/duplicity/mysql'.
Using installed duplicity version 0.7.06, python 2.7.12, gpg 1.4.20 (Home: ~/.gnupg), awk 'GNU Awk 4.1.3, API: 1.1 (GNU MPFR 3.1.4, GNU MP 6.1.0)', bash '4.3.48(1)-release (x86_64-pc-linux-gnu)'.
Checking TEMP_DIR '/tmp' is a folder (OK)
Checking TEMP_DIR '/tmp' is writable (OK)
TODO: reimplent tmp space check
Test - En/Decryption skipped. (GPG disabled)

--- Start running command PRE at 11:36:35.210 ---
Running '/etc/duplicity/mysql/pre' - FAILED (code 2)
Output: mysqldump: [Warning] Using a password on the command line interface can be insecure.
mysqldump: Got error: 2002: Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2) when trying to connect
11:36:35.222 Task 'PRE' failed with exit code '2'.
--- Finished state FAILED 'code 2' at 11:36:35.222 - Runtime 00:00:00.012 ---

--- Start running command BKP at 11:36:35.234 ---
Warning: Option --exclude-globbing-filelist is pending deprecation and will be removed in a future release.
--include-filelist and --exclude-filelist now accept globbing characters and should be used instead.
Reading globbing filelist /etc/duplicity/mysql/exclude
Local and Remote metadata are synchronized, no sync needed.
Last full backup date: Tue Oct 31 13:48:54 2017
--------------[ Backup Statistics ]--------------
StartTime 1510054595.49 (Tue Nov  7 11:36:35 2017)
EndTime 1510054595.49 (Tue Nov  7 11:36:35 2017)
ElapsedTime 0.00 (0.00 seconds)
SourceFiles 1
SourceFileSize 0 (0 bytes)
NewFiles 0
NewFileSize 0 (0 bytes)
DeletedFiles 0
ChangedFiles 1
ChangedFileSize 0 (0 bytes)
ChangedDeltaSize 0 (0 bytes)
DeltaEntries 1
RawDeltaSize 5 (5 bytes)
TotalDestinationSizeChange 98 (98 bytes)
Errors 0
-------------------------------------------------

--- Finished state OK at 11:36:35.579 - Runtime 00:00:00.344 ---

--- Start running command POST at 11:36:35.587 ---
Running '/etc/duplicity/mysql/post' - OK
--- Finished state OK at 11:36:35.598 - Runtime 00:00:00.011 ---
```

@sidorovdmitry 
@imatviian 
@Marx86 
@a-kryachko 
please review