### PR TITLE
Add edx_ansible_source_repo to ansible-bootstrap script.

### DIFF
--- a/util/install/ansible-bootstrap.sh
+++ b/util/install/ansible-bootstrap.sh
@@ -151,7 +151,7 @@ if [[ "true" == "${RUN_ANSIBLE}" ]]; then
     make requirements
 
     cd "${CONFIGURATION_DIR}"/playbooks/edx-east
-    "${PYTHON_BIN}"/ansible-playbook edx_ansible.yml -i '127.0.0.1,' -c local -e "configuration_version=${CONFIGURATION_VERSION}"
+    "${PYTHON_BIN}"/ansible-playbook edx_ansible.yml -i '127.0.0.1,' -c local -e "configuration_version=${CONFIGURATION_VERSION}" -e "edx_ansible_source_repo=${CONFIGURATION_REPO}"
 
     # cleanup
     rm -rf "${ANSIBLE_DIR}"


### PR DESCRIPTION
problem:

`fatal: [127.0.0.1]: FAILED! => {"changed": false, "cmd": "/usr/bin/git checkout --force ginkgo-rg", "failed": true, "msg": "Failed to checkout ginkgo-rg", "rc": 1, "stderr": "error: pathspec 'ginkgo-rg' did not match any file(s) known to git.\n", "stderr_lines": ["error: pathspec 'ginkgo-rg' did not match any file(s) known to git."], "stdout": "", "stdout_lines": []}`

How to check:
`
sudo git clone ginkgo-rg-fix-bootstrap -b ginkgo-rg-fix-bootstrap /tmp/edx_ansible
CONFIGURATION_REPO=ginkgo-rg-fix-bootstrap CONFIGURATION_VERSION=ginkgo-rg-fix-bootstrap sudo -E /tmp/edx_ansible/util/install/ansible-bootstrap.sh`

output results after fix:

```
git -C /tmp/configuration/ status
On branch ginkgo-rg-fix-bootstrap
Your branch is up-to-date with 'origin/ginkgo-rg-fix-bootstrap'.
nothing to commit, working directory clean
```

```
git -C /edx/app/edx_ansible/edx_ansible/ status
On branch ginkgo-rg-fix-bootstrap
Your branch is up-to-date with 'origin/ginkgo-rg-fix-bootstrap'.
nothing to commit, working directory clean
```

playbook and variable: 
https://github.com/raccoongang/configuration/blob/ginkgo-rg/playbooks/edx-east/edx_ansible.yml#L10
https://github.com/raccoongang/configuration/blob/ginkgo-rg/playbooks/roles/edx_ansible/defaults/main.yml#L43

@sidorovdmitry 
@a-kryachko 
please review