### PR TITLE
Fix an environment: that needs braces

### DIFF
--- a/playbooks/roles/notifier/tasks/deploy.yml
+++ b/playbooks/roles/notifier/tasks/deploy.yml
@@ -91,7 +91,7 @@
     chdir: "{{ NOTIFIER_CODE_DIR }}"
   become: true
   become_user: "{{ notifier_user }}"
-  environment: notifier_env_vars
+  environment: "{{ notifier_env_vars }}"
   notify:
     - restart notifier-scheduler
     - restart notifier-celery-workers


### PR DESCRIPTION
error:
```
TASK [notifier : Syncdb] *******************************************************
 [WARNING]: could not parse environment value, skipping: [u'notifier_env_vars']
...
```

edx fix: https://github.com/edx/configuration/commit/f15937809a8fa5a10f289ad028346953d09081fb#diff-b5300e4a64e2d88613bff5508077acc3

please review
@sidorovdmitry 
@a-kryachko 
@hetmantsev 