### PR TITLE
Update main.yml

### DIFF
--- a/playbooks/roles/datadog/tasks/main.yml
+++ b/playbooks/roles/datadog/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - name: Add apt key for datadog
   apt_key:
-    id: "C7A7DA52"
+    id: "382E94DE"
     url: "{{ COMMON_UBUNTU_APT_KEYSERVER }}{{ datadog_apt_key }}"
     state: present
   tags:


### PR DESCRIPTION
Configuration Pull Request

Hosts that do not trust the new key when we switch will see an error on our repository when they run apt-get update (W: GPG error: https://apt.datadoghq.com stable Release: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY D3A80E30382E94DE or W: GPG error: https://apt.datadoghq.com stable Release: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 4B4593018387EEAF). They won’t be able to install or update the Agent.

Here is official Datadog solution: https://help.datadoghq.com/hc/en-us/articles/360000886852

Added new key to datadog role.
