### PR TITLE
Upgrade datadog version to 6.*.* from customer.

### DIFF
--- a/playbooks/roles/datadog/defaults/main.yml
+++ b/playbooks/roles/datadog/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 DATADOG_API_KEY: "SPECIFY_KEY_HERE"
 
-datadog_agent_version: '1:5.10.1-1'
+datadog_agent_version: '1:6.1.4-1'
 
 datadog_apt_key: "0x226AE980C7A7DA52"
 datadog_debian_pkgs:


### PR DESCRIPTION
Upgrade datadog version to 6.*.* from customer.

"As I can see in the Datadog Console you have installed the agent on only one of the instance “i-0594817c3ca350a1f”. Please use the latest and re-run so that the agent get upgraded. Thanks !"