### PR TITLE
[Fix] Remove DATADOG_API_KEY variable. ginkgo-rg

### DIFF
--- a/playbooks/roles/datadog/defaults/main.yml
+++ b/playbooks/roles/datadog/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 datadog_enabled: yes
 
-datadog_api_key: "{{ DATADOG_API_KEY }}"
+datadog_api_key: ""
 
 # default datadog.conf options
 datadog_config: {}


### PR DESCRIPTION
Small fix for old variable. It`s not needed anymore.
DATADOG_API_KEY - old
datadog_api_key - new (added to defaults).