### PR TITLE
fixed 'every minute' cron tasks to be not so frequent

### DIFF
--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -191,6 +191,7 @@
   cron:
     name: "log-ntp-alerts"
     job: "{{ COMMON_BIN_DIR }}/log-ntp-alerts.sh >/dev/null 2>&1"
+    minute: "3"
 
 - name: install logrotate configuration
   template:

--- a/playbooks/roles/mongo_3_0/tasks/main.yml
+++ b/playbooks/roles/mongo_3_0/tasks/main.yml
@@ -91,7 +91,7 @@
 - name: add serverStatus logging script to cron
   cron:
     name: mongostat logging job
-    minute: "*/3"
+    minute: "*/6"
     job: /edx/bin/log-mongo-serverStatus.sh >> {{ mongo_log_dir }}/serverStatus.log 2>&1
   become: yes
   when: MONGO_LOG_SERVERSTATUS

--- a/playbooks/roles/rabbitmq/tasks/main.yml
+++ b/playbooks/roles/rabbitmq/tasks/main.yml
@@ -119,6 +119,7 @@
   cron:
     name: "log-queue-lenghts"
     job: /usr/bin/timeout {{ rabbitmq_cron_timeout }} {{ rabbitmq_app_dir }}/log-rabbitmq-queues.sh >/dev/null 2>&1
+    minute: "*/5"
   tags:
     - "install"
     - "install:app-configuration"
@@ -128,6 +129,7 @@
   cron:
     name: "log-rabbitmq-memory-usage"
     job: /usr/bin/timeout {{ rabbitmq_cron_timeout }} {{ rabbitmq_app_dir }}/log-rabbitmq-memory.sh >/dev/null 2>&1
+    minute: "*/7"
   tags:
     - "install"
     - "install:app-configuration"


### PR DESCRIPTION
fixed 'every minute' cron tasks for ntp logging, rabbit queue logging and mongo_3 status logging to be not so frequent

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1:
