### PR TITLE
changed meaning of COMMON_HOSTNAME variable to be a FQDN hostname

### DIFF
--- a/playbooks/roles/common/templates/hosts.j2
+++ b/playbooks/roles/common/templates/hosts.j2
@@ -1,4 +1,4 @@
-127.0.0.1 {{ COMMON_HOSTNAME }} localhost
+127.0.0.1 {{ COMMON_HOSTNAME | lower }} {{ COMMON_HOSTNAME.split('.')[0] | lower }} localhost
 
 # The following lines are desirable for IPv6 capable hosts
 ::1 ip6-localhost ip6-loopback


### PR DESCRIPTION
Set up Ubuntu FQDN hostname as they do in https://help.ubuntu.com/community/Leafnode2#Set_a_FQDN