### PR TITLE
role edxapp: changed placement of reindex tasks to skip reindex on first run

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -393,6 +393,30 @@
     - remove
     - aws
 
+- name: reindex courses
+  expect:
+    command: "{{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py cms --settings={{ edxapp_settings }} reindex_course --all"
+    chdir: "{{ edxapp_code_dir }}"
+    responses:
+      "Do you want to continue": "y"
+    timeout: 2700
+  when: edxapp_installed is defined and celery_worker is not defined and not disable_edx_services
+  become_user: "{{ common_web_user }}"
+  tags:
+    - manage
+
+- name: reindex libraries
+  expect:
+    command: "{{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py cms --settings={{ edxapp_settings }} reindex_library --all"
+    chdir: "{{ edxapp_code_dir }}"
+    responses:
+      "Do you want to continue": "y"
+    timeout: 2700
+  when: edxapp_installed is defined and celery_worker is not defined and not disable_edx_services
+  become_user: "{{ common_web_user }}"
+  tags:
+    - manage
+
 - set_fact:
     edxapp_installed: true
 
@@ -414,30 +438,6 @@
     config: "{{ supervisor_cfg }}"
     state: restarted
   when: edxapp_installed is defined and celery_worker is defined and not disable_edx_services
-  become_user: "{{ common_web_user }}"
-  tags:
-    - manage
-
-- name: reindex courses
-  expect:
-    command: "{{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py cms --settings={{ edxapp_settings }} reindex_course --all"
-    chdir: "{{ edxapp_code_dir }}"
-    responses:
-      "Do you want to continue": "y"
-    timeout: 2700
-  when: edxapp_installed is defined and celery_worker is not defined and not disable_edx_services
-  become_user: "{{ common_web_user }}"
-  tags:
-    - manage
-
-- name: reindex libraries
-  expect:
-    command: "{{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py cms --settings={{ edxapp_settings }} reindex_library --all"
-    chdir: "{{ edxapp_code_dir }}"
-    responses:
-      "Do you want to continue": "y"
-    timeout: 2700
-  when: edxapp_installed is defined and celery_worker is not defined and not disable_edx_services
   become_user: "{{ common_web_user }}"
   tags:
     - manage


### PR DESCRIPTION
Configuration Pull Request
---

Change execution order of courses reindex task to be run after mongo service deployment when deployment is running very first time.

---

Make sure that the following steps are done before merging:

  - [x] A DevOps team member has approved the PR.