### PR TITLE
Add posibility to use mongo replicaSet ans authSource parameters.

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -103,7 +103,10 @@ EDXAPP_MONGO_PORT: 27017
 EDXAPP_MONGO_USER: 'edxapp'
 EDXAPP_MONGO_DB_NAME: 'edxapp'
 EDXAPP_MONGO_USE_SSL: False
-
+### --- RG CUSTOM
+EDXAPP_MONGO_REPLICASET: ''
+EDXAPP_MONGO_AUTHSOURCE: 'admin'
+### RG CUSTOM ---
 EDXAPP_MYSQL_DB_NAME: 'edxapp'
 EDXAPP_MYSQL_USER: 'edxapp001'
 EDXAPP_MYSQL_USER_ADMIN: 'root'
@@ -818,6 +821,10 @@ edxapp_generic_doc_store_config: &edxapp_generic_default_docstore
   user: "{{ EDXAPP_MONGO_USER }}"
   collection:  'modulestore'
   ssl: "{{ EDXAPP_MONGO_USE_SSL }}"
+  ### --- RG CUSTOM ---
+  replicaSet: "{{ EDXAPP_MONGO_REPLICASET }}"
+  source: "{{ EDXAPP_MONGO_AUTHSOURCE }}"
+  ### --- RG CUSTOM ---
   # https://api.mongodb.com/python/2.9.1/api/pymongo/mongo_client.html#module-pymongo.mongo_client
   socketTimeoutMS: 3000 # default is never timeout while the connection is open, this means it needs to explicitly close raising pymongo.errors.NetworkTimeout
   connectTimeoutMS: 2000 # default is 20000, I believe raises pymongo.errors.ConnectionFailure
@@ -901,7 +908,11 @@ edxapp_generic_auth_config:  &edxapp_generic_auth
     password: "{{ EDXAPP_MONGO_PASSWORD }}"
     port: "{{ EDXAPP_MONGO_PORT }}"
     user: "{{ EDXAPP_MONGO_USER }}"
-    ssl: "{{ EDXAPP_MONGO_USE_SSL }}"  
+    ssl: "{{ EDXAPP_MONGO_USE_SSL }}"
+    ### --- RG CUSTOM ---
+    replicaSet: "{{ EDXAPP_MONGO_REPLICASET }}"
+    source: "{{ EDXAPP_MONGO_AUTHSOURCE }}"
+    ### --- RG CUSTOM ---
   CONTENTSTORE:
     ENGINE:  'xmodule.contentstore.mongo.MongoContentStore'
     #
@@ -915,6 +926,10 @@ edxapp_generic_auth_config:  &edxapp_generic_auth
       port: "{{ EDXAPP_MONGO_PORT }}"
       user: "{{ EDXAPP_MONGO_USER }}"
       ssl: "{{ EDXAPP_MONGO_USE_SSL }}"
+      ### --- RG CUSTOM ---
+      replicaSet: "{{ EDXAPP_MONGO_REPLICASET }}"
+      source: "{{ EDXAPP_MONGO_AUTHSOURCE }}"
+      ### --- RG CUSTOM ---
     ADDITIONAL_OPTIONS: "{{ EDXAPP_CONTENTSTORE_ADDITIONAL_OPTS }}"
     DOC_STORE_CONFIG: *edxapp_generic_default_docstore
   DATABASES: "{{ edxapp_databases }}"


### PR DESCRIPTION
 
MongoAtlas require added parameters to connection.
Also added handling these parameters from platform side.

YT: https://youtrack.raccoongang.com/issue/ASUOSPP-462
GitLab AWX inventories: https://gitlab.raccoongang.com/DevOps/awx-deployment/merge_requests/2181
