### PR TITLE
AzStorage support in platform didn't support standard EDXAPP_GRADE_STORAGE_KWARGS, so plumbing through CONTAINER config until we fix. Originally checked in by Christy Henriksson

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1164,6 +1164,7 @@ generic_env_config:  &edxapp_generic_env
     STORAGE_TYPE: "{{ EDXAPP_GRADE_STORAGE_TYPE | default(None) }}"
     BUCKET: "{{ EDXAPP_GRADE_BUCKET | default(None) }}"
     ROOT_PATH: "{{ EDXAPP_GRADE_ROOT_PATH | default(None) }}"
+    CONTAINER: "{{ EDXAPP_GRADE_STORAGE_CONTAINER | default(None) }}"
   STATIC_ROOT_BASE: "{{ edxapp_staticfile_dir }}"
   LMS_BASE: "{{ EDXAPP_LMS_BASE }}"
   CMS_BASE: "{{ EDXAPP_CMS_BASE }}"


### PR DESCRIPTION
Configuration Pull Request
---

Azure storage for grades downloads.

cherry-pick of [this commit](https://github.com/raccoongang/configuration/commit/309b230158cef72bc32419a75276c2769c5ace15) from `ginkgo-rg` branch

Ticket: https://youtrack.raccoongang.com/issue/FLS-45