### PR TITLE
roles rabbitmq: fix for 'gzip: stdin: file size changed while zipping…

### DIFF
--- a/playbooks/roles/rabbitmq/templates/etc/logrotate.d/rabbitmq.j2
+++ b/playbooks/roles/rabbitmq/templates/etc/logrotate.d/rabbitmq.j2
@@ -8,4 +8,7 @@
   daily
   rotate 3
   nocreate
+  postrotate
+    /etc/init.d/rabbitmq-server rotate-logs > /dev/null
+  endscript
 }


### PR DESCRIPTION
Configuration Pull Request
---

Added postrotate for rabbitmq logrotate configuration to get rid of spamming local mailboxes with this message:

```
/etc/cron.daily/logrotate:
gzip: stdin: file size changed while zipping
```

If changes are made as part of the base installation, then you need to issue a pull requests to all the basic branches:
- [x] ficus-rg
- [x] gingko-rg
- [x] hawthorn-rg
- [x] development gingko-rg
- [x] development hawthorn-rg
