### PR TITLE
Update elasticsearch.yml.j2 (#152)

### DIFF
--- a/playbooks/roles/elasticsearch/templates/edx/etc/elasticsearch/elasticsearch.yml.j2
+++ b/playbooks/roles/elasticsearch/templates/edx/etc/elasticsearch/elasticsearch.yml.j2
@@ -43,3 +43,9 @@ discovery.zen.ping.unicast.hosts: ['{{ELASTICSEARCH_CLUSTER_MEMBERS|join("\',\'"
 network:
   host: {{ ansible_ssh_host }}
 {% endif %}
+
+{% if ELASTICSEARCH_CLUSTERED is defined and not ELASTICSEARCH_CLUSTERED | bool %}
+# RG fix:
+discovery.zen.ping.multicast.enabled: false
+node.local: true
+{% endif %}


### PR DESCRIPTION
Configuration Pull Request
---

Setting `ELASTICSEARCH_CLUSTERED: False` disables elasticsearch discovery.

Cherry-pick from https://github.com/raccoongang/configuration/commit/44e98a011c1d39cb75eba25f0f564ed339ac937a