### PR TITLE
hawthorn-rg: roles/edxapp: added pip version pinning for edxapp-sandbox virtualenv deployment

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -270,6 +270,28 @@
     - install
     - install:app-requirements
 
+- name: code sandbox | Create the virtualenv to install the Python requirements
+  command: "virtualenv {{ edxapp_sandbox_venv_dir }}"
+  args:
+    chdir: "{{ edxapp_code_dir }}"
+    creates: "{{ edxapp_sandbox_venv_dir }}/bin/pip"
+  become_user: "{{ edxapp_sandbox_user }}"
+  environment: "{{ edxapp_environment }}"
+  tags:
+    - edxapp-sandbox
+    - install
+    - install:app-requirements
+
+- name: code sandbox | Pin pip to a specific version.
+  command: "{{ edxapp_sandbox_venv_dir }}/bin/pip install pip=={{ common_pip_version }}"
+  args:
+    chdir: "{{ edxapp_code_dir }}"
+  become_user: "{{ edxapp_sandbox_user }}"
+  tags:
+    - edxapp-sandbox
+    - install
+    - install:app-requirements
+
 - name: code sandbox | Install base sandbox requirements and create sandbox virtualenv
   pip:
     chdir: "{{ edxapp_code_dir }}"


### PR DESCRIPTION
pip version pin to same version as for edxapp virtualenv

new pip version builds modules in module directory and throw this error:

```
       cwd: /edx/app/edxapp/edx-platform/common/lib/sandbox-packages/
  Complete output (5 lines):
  running bdist_wheel
  running build
  running build_py
  creating build
  error: could not create 'build': Permission denied
  ----------------------------------------
```
---

If changes are made as part of the base installation, then you need to issue a pull requests to all the basic branches:
- [ ] ficus-rg
- [ ] gingko-rg
- [x] hawthorn-rg
- [ ] development gingko-rg
- [ ] development hawthorn-rg
